### PR TITLE
[Configuración] Activar tema remoto Cayman

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,7 +31,7 @@ twitter_username: mvallessanchez
 github_username:  mvalles
 
 # Build settings
-theme: minima
+#theme: minima
 remote_theme: pages-themes/cayman@v0.2.0
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Configura tema remoto Cayman porque parece ser que cogia erroneamente el que viene por defecto (minima). Se cambia theme por remote_theme.